### PR TITLE
Update Pot Raiders link on home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,7 +46,7 @@ export default async function Home() {
               title="Pot Raiders"
               description="Minting soon"
               image={"/images/raider.svg"}
-              link="https://farcaster.xyz/andreitr.eth/0x0857a3b9"
+              link="https://farcaster.xyz/andreitr.eth/0x3128f0cd"
             />
             <FeatureBasePaintCard
               title="Mint BasePaint"


### PR DESCRIPTION
## Summary
- update Pot Raiders link to new Farcaster URL

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68962628edfc8332aa9f50318a8b0474