### PR TITLE
Reduce BBITS burn amount

### DIFF
--- a/app/api/cron/burn/route.ts
+++ b/app/api/cron/burn/route.ts
@@ -26,8 +26,8 @@ export async function GET(req: NextRequest) {
     );
 
     const signer = new Wallet(process.env.BURNER_BOT_PK as string, provider);
-    const burnAmount = parseUnits("0.0004", 18);
-    const minAmount = parseUnits("0.00045", 18);
+    const burnAmount = parseUnits("0.0002", 18);
+    const minAmount = parseUnits("0.00025", 18);
 
     // Check wallet balance before proceeding
     const ethBalance = await provider.getBalance(signer.address);


### PR DESCRIPTION
## Summary
- halve BBITS burn amount to 0.0002 ETH and adjust balance check threshold accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897f6c2ae3483329f3dbe983f988c9c