### PR TITLE
Remove aeye token mint cron job

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -45,14 +45,6 @@
       "schedule": "55 17 * * *"
     },
     {
-      "path": "/api/cron/aeye/mint",
-      "schedule": "0 18 * * *"
-    },
-    {
-      "path": "/api/cron/aeye/mint",
-      "schedule": "2 18 * * *"
-    },
-    {
       "path": "/api/cron/potraider",
       "schedule": "30 19 * * *"
     },


### PR DESCRIPTION
## Summary
- remove `/api/cron/aeye/mint` from Vercel cron schedule to stop automatic AEYE token minting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e28b34488332ba2dec8a6bec8407