### PR TITLE
Update potraider terminology

### DIFF
--- a/app/potraider/components/MintComponent.tsx
+++ b/app/potraider/components/MintComponent.tsx
@@ -62,7 +62,7 @@ export const MintComponent = ({
               </div>
               <div className="flex flex-col gap-2">
                 <div className="uppercase text-xs text-gray-400 flex items-center gap-1">
-                  Daily Spent
+                  Daily Spend
                 </div>
                 <div className="text-2xl text-[#FEC94F]">
                   {Number(formatUnits(dailySpent, 18)).toFixed(5)}Ξ

--- a/app/potraider/components/MintComponent.tsx
+++ b/app/potraider/components/MintComponent.tsx
@@ -62,7 +62,7 @@ export const MintComponent = ({
               </div>
               <div className="flex flex-col gap-2">
                 <div className="uppercase text-xs text-gray-400 flex items-center gap-1">
-                  Daily Pool
+                  Daily Spent
                 </div>
                 <div className="text-2xl text-[#FEC94F]">
                   {Number(formatUnits(dailySpent, 18)).toFixed(5)}Ξ
@@ -70,7 +70,7 @@ export const MintComponent = ({
               </div>
               <div className="flex flex-col gap-2">
                 <div className="uppercase text-xs text-gray-400 flex items-center gap-1">
-                  Duration / Days
+                  Days
                 </div>
                 <div className="text-2xl text-[#FEC94F]">
                   {currentDay}/{totalDays}

--- a/app/potraider/components/UserComponent.tsx
+++ b/app/potraider/components/UserComponent.tsx
@@ -37,7 +37,7 @@ export const UserComponent = ({ redeemValue, circulatingSupply }: Props) => {
       {balance && (
         <div className="flex flex-col gap-2">
           <div className="uppercase text-xs text-gray-400 flex items-center gap-1">
-            Redeem Value
+            Total Value
           </div>
           <div className="text-2xl ">
             {Number(formatUnits(redeemValue[0] * BigInt(balance), 18)).toFixed(
@@ -60,7 +60,7 @@ export const UserComponent = ({ redeemValue, circulatingSupply }: Props) => {
       {balance && (
         <div className="flex flex-col gap-2">
           <div className="uppercase text-xs text-gray-400 flex items-center gap-1">
-            Treasury Percentage
+            Treasury Share
           </div>
           <div className="text-2xl ">
             {(Number(balance) / Number(circulatingSupply)) * 100}%


### PR DESCRIPTION
## Summary
- rename Redeem Value to Total Value and Treasury Percentage to Treasury Share in UserComponent
- rename Daily Pool to Daily Spent and Duration / Days to Days in MintComponent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a2ecfdb70833298afe9fb7f7f9281