### PR TITLE
Remove aeye mint component from home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,13 +8,7 @@ import { ClientWrapper } from "@/app/lib/components/ClientWrapper";
 import { FeatureBasePaintCard } from "@/app/lib/components/FeatureBasePaintCard";
 import { FeatureCard } from "@/app/lib/components/FeatureCard";
 import { Footer } from "@/app/lib/components/Footer";
-import { MintComponent } from "./aeye/components/MintComponent";
-import { getAeyeById } from "./lib/api/aeye/getAeyeById";
-import { getCurrentMint } from "./lib/api/aeye/getCurrentMint";
-
-export default async function Home() {
-  const currentMint = await getCurrentMint();
-  const aeye = await getAeyeById(currentMint);
+export default function Home() {
 
   return (
     <div className="flex flex-col justify-center items-center w-full">
@@ -55,14 +49,6 @@ export default async function Home() {
           </div>
         </div>
       </div>
-
-      {aeye && (
-        <div className="flex justify-center items-center w-full pt-10 pb-8 mt-10 md:mt-0">
-          <div className="container max-w-screen-lg mb-8">
-            <MintComponent token={aeye} />
-          </div>
-        </div>
-      )}
 
       <div className="flex justify-center items-center w-full bg-[#859985] px-10 lg:px-0 pb-8 sm:pb-0">
         <div className="container max-w-screen-lg mb-10 mt-10">


### PR DESCRIPTION
## Summary
- remove aeye MintComponent and related data fetching from home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a70b6bc5883328da0bab9f25aa999