### PR TITLE
feat: add pot raider reward for streaks

### DIFF
--- a/app/lib/components/CheckInGoodies.tsx
+++ b/app/lib/components/CheckInGoodies.tsx
@@ -45,7 +45,10 @@ export const CheckInGoodies = ({ checkin, address }: Props) => {
           </Link>
         </div>
         <div>{"• Receive daily BBITS airdrop"}</div>
-        {user?.farcaster_name && streak > 7 && (
+        {streak >= 7 && (
+          <div>{"• Receive Pot Raider NFT 💀 on August 19"}</div>
+        )}
+        {user?.farcaster_name && streak >= 7 && (
           <div>{"• Receive weekly Farcaster airdrop"}</div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- show Pot Raider NFT message for users with streaks of seven or more and include distribution date
- align weekly Farcaster airdrop to trigger at the same streak threshold

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e3f80d7848332bbf4834ad18871de