### PR TITLE
feat: show potraider mint progress

### DIFF
--- a/app/potraider/components/MintButton.tsx
+++ b/app/potraider/components/MintButton.tsx
@@ -3,6 +3,7 @@
 import { PotRaiderABI } from "@/app/lib/abi/PotRaider.abi";
 import { Button } from "@/app/lib/components/Button";
 import { useSocialDisplay } from "@/app/lib/hooks/useSocialDisplay";
+import Link from "next/link";
 import { useModal } from "connectkit";
 import { formatUnits } from "ethers";
 import { useEffect, useState } from "react";
@@ -36,6 +37,15 @@ export const MintButton = () => {
     functionName: "mintPrice",
     chainId: base.id,
   });
+
+  const { data: totalSupply } = useReadContract({
+    abi: PotRaiderABI,
+    address: process.env.NEXT_PUBLIC_RAIDER_ADDRESS as `0x${string}`,
+    functionName: "totalSupply",
+    chainId: base.id,
+  });
+
+  const mintedCount = totalSupply ? Number(totalSupply) : 0;
 
   const { show } = useSocialDisplay({
     message: `I just minted a PotRaider NFT on @basedbits!`,
@@ -74,60 +84,89 @@ export const MintButton = () => {
     setQuantity((q) => Math.max(1, q - 1));
   };
 
+  const mintedInfo = (
+    <div className="text-center text-white">{mintedCount} of 1000 minted</div>
+  );
+
+  if (mintedCount >= 1000) {
+    return (
+      <div className="text-center text-white">
+        Collection is minted out, buy{" "}
+        <Link
+          href="https://opensea.io/collection/pot-raiders"
+          target="_blank"
+          className="underline"
+        >
+          secondary
+        </Link>
+        .
+      </div>
+    );
+  }
+
   if (!isConnected) {
     return (
-      <Button
-        className={
-          "bg-[#FEC94F]/10 text-white/80 hover:text-white font-regular sm:w-auto"
-        }
-        onClick={() => setOpen(true)}
-      >
-        Connect to Mint
-      </Button>
+      <div className="flex flex-col items-center w-full gap-2">
+        {mintedInfo}
+        <Button
+          className={
+            "bg-[#FEC94F]/10 text-white/80 hover:text-white font-regular sm:w-auto"
+          }
+          onClick={() => setOpen(true)}
+        >
+          Connect to Mint
+        </Button>
+      </div>
     );
   }
 
   if (chainId !== base.id) {
     return (
-      <Button
-        className={
-          "bg-[#FEC94F]/10 text-white/60 font-regular w-full sm:w-auto"
-        }
-        onClick={() => switchChain({ chainId: base.id })}
-      >
-        Switch to Base
-      </Button>
+      <div className="flex flex-col items-center w-full gap-2">
+        {mintedInfo}
+        <Button
+          className={
+            "bg-[#FEC94F]/10 text-white/60 font-regular w-full sm:w-auto"
+          }
+          onClick={() => switchChain({ chainId: base.id })}
+        >
+          Switch to Base
+        </Button>
+      </div>
     );
   }
 
   return (
-    <div className="flex flex-row gap-4 items-center w-full ">
-      <div className="flex items-center border border-[#FEC94F]/30 rounded-lg h-[50px]">
-        <button
-          className="px-3 py-1 text-xl text-white/80 hover:text-white disabled:text-white/30"
-          onClick={decrement}
-          disabled={quantity <= 1}
+    <div className="flex flex-col items-center w-full gap-2">
+      {mintedInfo}
+      <div className="flex flex-row gap-4 items-center w-full ">
+        <div className="flex items-center border border-[#FEC94F]/30 rounded-lg h-[50px]">
+          <button
+            className="px-3 py-1 text-xl text-white/80 hover:text-white disabled:text-white/30"
+            onClick={decrement}
+            disabled={quantity <= 1}
+          >
+            -
+          </button>
+          <div className="px-2 w-8 text-center text-white">{quantity}</div>
+          <button
+            className="px-3 py-1 text-xl text-white/80 hover:text-white disabled:text-white/30"
+            onClick={increment}
+            disabled={quantity >= 50}
+          >
+            +
+          </button>
+        </div>
+        <Button
+          className={"bg-[#FEC94F]/10 font-regular w-full sm:w-auto flex-1"}
+          onClick={() => {
+            mint();
+          }}
+          loading={!mintPrice || isFetching}
         >
-          -
-        </button>
-        <div className="px-2 w-8 text-center text-white">{quantity}</div>
-        <button
-          className="px-3 py-1 text-xl text-white/80 hover:text-white disabled:text-white/30"
-          onClick={increment}
-          disabled={quantity >= 50}
-        >
-          +
-        </button>
+          {isFetching ? "Minting..." : label}
+        </Button>
       </div>
-      <Button
-        className={"bg-[#FEC94F]/10 font-regular w-full sm:w-auto flex-1"}
-        onClick={() => {
-          mint();
-        }}
-        loading={!mintPrice || isFetching}
-      >
-        {isFetching ? "Minting..." : label}
-      </Button>
     </div>
   );
 };

--- a/app/potraider/components/MintButton.tsx
+++ b/app/potraider/components/MintButton.tsx
@@ -3,7 +3,6 @@
 import { PotRaiderABI } from "@/app/lib/abi/PotRaider.abi";
 import { Button } from "@/app/lib/components/Button";
 import { useSocialDisplay } from "@/app/lib/hooks/useSocialDisplay";
-import Link from "next/link";
 import { useModal } from "connectkit";
 import { formatUnits } from "ethers";
 import { useEffect, useState } from "react";
@@ -16,6 +15,8 @@ import {
   useWriteContract,
 } from "wagmi";
 import { base } from "wagmi/chains";
+
+const MAX_MINT_PER_TX = 50;
 
 export const MintButton = () => {
   const { setOpen } = useModal();
@@ -37,15 +38,6 @@ export const MintButton = () => {
     functionName: "mintPrice",
     chainId: base.id,
   });
-
-  const { data: totalSupply } = useReadContract({
-    abi: PotRaiderABI,
-    address: process.env.NEXT_PUBLIC_RAIDER_ADDRESS as `0x${string}`,
-    functionName: "totalSupply",
-    chainId: base.id,
-  });
-
-  const mintedCount = totalSupply ? Number(totalSupply) : 0;
 
   const { show } = useSocialDisplay({
     message: `I just minted a PotRaider NFT on @basedbits!`,
@@ -77,37 +69,16 @@ export const MintButton = () => {
   }, [isSuccess, show]);
 
   const increment = () => {
-    setQuantity((q) => Math.min(50, q + 1));
+    setQuantity((q) => Math.min(MAX_MINT_PER_TX, q + 1));
   };
 
   const decrement = () => {
     setQuantity((q) => Math.max(1, q - 1));
   };
 
-  const mintedInfo = (
-    <div className="text-center text-white">{mintedCount} of 1000 minted</div>
-  );
-
-  if (mintedCount >= 1000) {
-    return (
-      <div className="text-center text-white">
-        Collection is minted out, buy{" "}
-        <Link
-          href="https://opensea.io/collection/pot-raiders"
-          target="_blank"
-          className="underline"
-        >
-          secondary
-        </Link>
-        .
-      </div>
-    );
-  }
-
   if (!isConnected) {
     return (
       <div className="flex flex-col items-center w-full gap-2">
-        {mintedInfo}
         <Button
           className={
             "bg-[#FEC94F]/10 text-white/80 hover:text-white font-regular sm:w-auto"
@@ -123,7 +94,6 @@ export const MintButton = () => {
   if (chainId !== base.id) {
     return (
       <div className="flex flex-col items-center w-full gap-2">
-        {mintedInfo}
         <Button
           className={
             "bg-[#FEC94F]/10 text-white/60 font-regular w-full sm:w-auto"
@@ -138,9 +108,8 @@ export const MintButton = () => {
 
   return (
     <div className="flex flex-col items-center w-full gap-2">
-      {mintedInfo}
-      <div className="flex flex-row gap-4 items-center w-full ">
-        <div className="flex items-center border border-[#FEC94F]/30 rounded-lg h-[50px]">
+      <div className="flex sm:flex-row flex-col gap-4 items-center w-full ">
+        <div className="flex items-center border border-[#FEC94F]/30 rounded-lg h-[50px] w-full sm:w-auto justify-center">
           <button
             className="px-3 py-1 text-xl text-white/80 hover:text-white disabled:text-white/30"
             onClick={decrement}
@@ -152,7 +121,7 @@ export const MintButton = () => {
           <button
             className="px-3 py-1 text-xl text-white/80 hover:text-white disabled:text-white/30"
             onClick={increment}
-            disabled={quantity >= 50}
+            disabled={quantity >= MAX_MINT_PER_TX}
           >
             +
           </button>

--- a/app/potraider/components/MintComponent.tsx
+++ b/app/potraider/components/MintComponent.tsx
@@ -5,7 +5,7 @@ import { MintButton } from "@/app/potraider/components/MintButton";
 import { formatUnits } from "ethers";
 
 interface Props {
-  count: number;
+  totalSupply: number;
   lastJackpotEndTime: number;
   dailySpent: number;
   jackpot: number;
@@ -16,7 +16,7 @@ interface Props {
 }
 
 export const MintComponent = ({
-  count,
+  totalSupply,
   lastJackpotEndTime,
   dailySpent,
   jackpot,
@@ -25,6 +25,9 @@ export const MintComponent = ({
   contractBalance,
   redeemValue,
 }: Props) => {
+  const mintProgress = (Number(totalSupply) / 1000) * 100;
+  const isMintInProgress = mintProgress < 100;
+
   return (
     <div className="w-full flex flex-col md:flex-row gap-10 sm:gap-20 justify-between bg-black/90 rounded-lg text-white p-5">
       <div className="flex flex-col sm:flex-row w-full gap-5">
@@ -82,6 +85,14 @@ export const MintComponent = ({
                 </div>
                 <div className="text-2xl text-[#FEC94F]">
                   {Number(formatUnits(contractBalance, 18)).toFixed(5)}Ξ
+                </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                <div className="uppercase text-xs text-gray-400 flex items-center gap-1">
+                  {isMintInProgress ? "Mint In Progress" : "Minted"}
+                </div>
+                <div className="text-2xl text-[#FEC94F]">
+                  {isMintInProgress ? `${mintProgress}%` : "Minted"}
                 </div>
               </div>
             </div>

--- a/app/potraider/components/MintComponent.tsx
+++ b/app/potraider/components/MintComponent.tsx
@@ -12,7 +12,6 @@ interface Props {
   totalDays: number;
   currentDay: number;
   contractBalance: bigint;
-  redeemValue: [bigint, bigint]; // [ethShare, usdcShare]
 }
 
 export const MintComponent = ({
@@ -23,10 +22,8 @@ export const MintComponent = ({
   totalDays,
   currentDay,
   contractBalance,
-  redeemValue,
 }: Props) => {
   const mintProgress = (Number(totalSupply) / 1000) * 100;
-  const isMintInProgress = mintProgress < 100;
 
   return (
     <div className="w-full flex flex-col md:flex-row gap-10 sm:gap-20 justify-between bg-black/90 rounded-lg text-white p-5">
@@ -54,7 +51,7 @@ export const MintComponent = ({
                 <div className="uppercase text-xs text-gray-400">
                   Next Drawing
                 </div>
-                <div className="text-3xl text-[#FEC94F]">
+                <div className="text-2xl text-[#FEC94F]">
                   {
                     <CountDownToDate
                       targetDate={Number(lastJackpotEndTime) + 86400}
@@ -71,14 +68,7 @@ export const MintComponent = ({
                   {Number(formatUnits(dailySpent, 18)).toFixed(5)}Ξ
                 </div>
               </div>
-              <div className="flex flex-col gap-2">
-                <div className="uppercase text-xs text-gray-400 flex items-center gap-1">
-                  Days
-                </div>
-                <div className="text-2xl text-[#FEC94F]">
-                  {currentDay}/{totalDays}
-                </div>
-              </div>
+
               <div className="flex flex-col gap-2">
                 <div className="uppercase text-xs text-gray-400 flex items-center gap-1">
                   Treasury
@@ -89,10 +79,10 @@ export const MintComponent = ({
               </div>
               <div className="flex flex-col gap-2">
                 <div className="uppercase text-xs text-gray-400 flex items-center gap-1">
-                  {isMintInProgress ? "Mint In Progress" : "Minted"}
+                  Mint Progress
                 </div>
                 <div className="text-2xl text-[#FEC94F]">
-                  {isMintInProgress ? `${mintProgress}%` : "Minted"}
+                  {mintProgress}%
                 </div>
               </div>
             </div>

--- a/app/potraider/page.tsx
+++ b/app/potraider/page.tsx
@@ -73,7 +73,7 @@ export default async function Page() {
 
           <div className="flex flex-col gap-4">
             <MintComponent
-              count={circulatingSupply}
+              totalSupply={totalSupply}
               lastJackpotEndTime={lastJackpotEndTime}
               dailySpent={dailySpent}
               jackpot={jackpot}

--- a/app/potraider/page.tsx
+++ b/app/potraider/page.tsx
@@ -80,7 +80,7 @@ export default async function Page() {
               totalDays={totalDays}
               currentDay={currentDay}
               contractBalance={contractBalance}
-              redeemValue={redeemValue}
+              
             />
 
             <div className="mb-12 flex flex-col gap-4">


### PR DESCRIPTION
## Summary
- show current mint count above PotRaider mint controls
- replace mint interface with link to OpenSea collection when supply is exhausted

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e487078248332a4ecd11449dfa1b2