### PR TITLE
feat: show Pot Raider purchase history

### DIFF
--- a/app/raid/history/page.tsx
+++ b/app/raid/history/page.tsx
@@ -3,9 +3,6 @@
 import { Header } from "@/app/lib/components/client/Header";
 import { Footer } from "@/app/lib/components/Footer";
 import { potraiderContract } from "@/app/lib/contracts/potraider";
-import { MintComponent } from "@/app/raid/components/MintComponent";
-import { NFTList } from "@/app/raid/components/NFTList";
-import { UserComponent } from "@/app/raid/components/UserComponent";
 import { formatUnits } from "ethers";
 
 export async function generateMetadata() {
@@ -48,19 +45,57 @@ export default async function Page() {
   const contract = potraiderContract();
 
   const currentDay = await contract.currentLotteryDay();
+  const latestDay = currentDay > 0 ? Number(currentDay) : 0;
+  const days = Array.from({ length: latestDay + 1 }, (_, i) => i);
 
-  const history = await contract.lotteryPurchaseHistory(
-    currentDay > 0 ? Number(currentDay) : 0,
+  const history = await Promise.all(
+    days.map((day) => contract.lotteryPurchaseHistory(day)),
   );
 
   return (
-    <div className="flex flex-col justify-center items-ce ter w-full">
+    <div className="flex flex-col justify-center items-center w-full">
       <div className="flex justify-center items-center w-full bg-[#DDF5DD] px-0 lg:px-10 pb-8 sm:pb-0">
         <div className="container max-w-screen-lg">
           <Header />
 
           <div className="flex flex-col gap-4">
-            Purchase History for Day {currentDay}
+            <div className="text-xl font-semibold">Purchase History</div>
+            <table className="w-full text-left">
+              <thead>
+                <tr className="border-b border-gray-300 text-sm">
+                  <th className="py-2">Day</th>
+                  <th className="py-2">Timestamp</th>
+                  <th className="py-2">Tickets</th>
+                </tr>
+              </thead>
+              <tbody>
+                {history
+                  .map((entry, index) => ({ day: days[index], entry }))
+                  .reverse()
+                  .map(({ day, entry }) => (
+                    <tr
+                      key={day}
+                      className="border-b border-gray-200 last:border-b-0"
+                    >
+                      <td className="py-2">{day}</td>
+                      <td className="py-2">
+                        {Number(entry[1]) > 0
+                          ? new Date(Number(entry[1]) * 1000).toLocaleString(
+                              "en-US",
+                              {
+                                month: "short",
+                                day: "numeric",
+                                hour: "2-digit",
+                                minute: "2-digit",
+                              },
+                            )
+                          : "-"}
+                      </td>
+                      <td className="py-2">{entry[0].toString()}</td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `/raid/history` page that lists daily purchase history with timestamp and tickets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adf33c15b483329609c747a9f5e8d9