### PR TITLE
chore: run burn cron twice an hour

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/burn",
-      "schedule": "0 * * * *"
+      "schedule": "*/30 * * * *"
     },
     {
       "path": "/api/cron/airdrop",


### PR DESCRIPTION
## Summary
- run burn cron every 30 minutes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7b1b44f6c83328f2c4600556c3001