### PR TITLE
chore: lower burn min balance

### DIFF
--- a/app/api/cron/burn/route.ts
+++ b/app/api/cron/burn/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: NextRequest) {
 
     const signer = new Wallet(process.env.BURNER_BOT_PK as string, provider);
     const burnAmount = parseUnits("0.0002", 18);
-    const minAmount = parseUnits("0.00025", 18);
+    const minAmount = parseUnits("0.00022", 18);
 
     // Check wallet balance before proceeding
     const ethBalance = await provider.getBalance(signer.address);


### PR DESCRIPTION
## Summary
- lower burn cron minimum ETH balance to 0.00022

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c08f8ac6ec833296d854889c0fdea6