### PR TITLE
Add mint function to BasePaint ABI

### DIFF
--- a/app/lib/abi/BasePaint.abi.ts
+++ b/app/lib/abi/BasePaint.abi.ts
@@ -1,5 +1,15 @@
 export const BasePaintAbi = [
   {
+    inputs: [
+      { internalType: "uint256", name: "day", type: "uint256" },
+      { internalType: "uint256", name: "count", type: "uint256" },
+    ],
+    name: "mint",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
     inputs: [],
     name: "today",
     outputs: [{ internalType: "uint256", name: "", type: "uint256" }],


### PR DESCRIPTION
## Summary
- add the BasePaint contract's payable mint(day,count) function to the ABI used by the app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d84cb613d48332aab64c9648848a2f