### PR TITLE
Lazy load Wagmi config in Web3Provider

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ export default async function RootLayout({
       <body className="font-mono">
         <Toaster />
         <SpeedInsights />
-        <Web3Provider>{children}</Web3Provider>
+        <Web3Provider cookie={cookie}>{children}</Web3Provider>
       </body>
     </html>
   );

--- a/app/lib/Web3Provider.tsx
+++ b/app/lib/Web3Provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useMemo } from "react";
 import {
   cookieStorage,
   cookieToInitialState,
@@ -14,26 +14,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ConnectKitProvider, getDefaultConfig } from "connectkit";
 import { baseRpcUrl, baseTestnetRpcUrl } from "@/app/lib/Web3Configs";
 
-const wagmiConfig = createConfig(
-  getDefaultConfig({
-    ssr: true,
-    storage: createStorage({
-      storage: cookieStorage,
-    }),
-    chains: [base, baseSepolia],
-    transports: {
-      [base.id]: http(baseRpcUrl),
-      [baseSepolia.id]: http(baseTestnetRpcUrl),
-    },
-    walletConnectProjectId: process.env
-      .NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string,
-    appName: "Based Bits",
-    appDescription: "Based Bits causing byte-sized mischief on the BASE chain.",
-    appUrl: "https://basedbits.fun",
-    appIcon: "https://www.basedbits.fun/images/icon.png",
-  }),
-);
-
 const queryClient = new QueryClient();
 
 export const Web3Provider = ({
@@ -43,6 +23,40 @@ export const Web3Provider = ({
   cookie?: string | null;
   children: ReactNode;
 }>) => {
+  const wagmiConfig = useMemo(() => {
+    const sharedConfig = {
+      ssr: true,
+      storage: createStorage({
+        storage: cookieStorage,
+      }),
+      chains: [base, baseSepolia],
+      transports: {
+        [base.id]: http(baseRpcUrl),
+        [baseSepolia.id]: http(baseTestnetRpcUrl),
+      },
+    } as const;
+
+    if (typeof window === "undefined") {
+      return createConfig({
+        ...sharedConfig,
+        connectors: [],
+      });
+    }
+
+    return createConfig(
+      getDefaultConfig({
+        ...sharedConfig,
+        walletConnectProjectId: process.env
+          .NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID as string,
+        appName: "Based Bits",
+        appDescription:
+          "Based Bits causing byte-sized mischief on the BASE chain.",
+        appUrl: "https://basedbits.fun",
+        appIcon: "https://www.basedbits.fun/images/icon.png",
+      }),
+    );
+  }, []);
+
   const initialState = cookieToInitialState(wagmiConfig, cookie);
 
   return (


### PR DESCRIPTION
## Summary
- Lazy-load the Wagmi configuration inside the Web3Provider so WalletConnect connectors are only created in the browser
- Provide a server-safe fallback config without WalletConnect for SSR rendering
- Pass request cookies from the root layout to Web3Provider for initializing state with the new lazy config

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e19dfb16ac8332b1ee268912e83aa1