### PR TITLE
Fix trader cron to list freshly minted BasePaint NFTs

### DIFF
--- a/app/api/cron/trader/route.ts
+++ b/app/api/cron/trader/route.ts
@@ -1,6 +1,14 @@
 import { BasePaintRewardsAbi } from "@/app/lib/abi/BasePaintRewards.abi";
 import { baseRpcUrl } from "@/app/lib/Web3Configs";
-import { Contract, JsonRpcProvider, Wallet, getAddress } from "ethers";
+import {
+  Contract,
+  Interface,
+  JsonRpcProvider,
+  Log,
+  Wallet,
+  ZeroAddress,
+  getAddress,
+} from "ethers";
 import { Chain, OpenSeaSDK, TokenStandard } from "opensea-js";
 import { NextRequest } from "next/server";
 
@@ -14,6 +22,14 @@ const LISTING_DURATION_SECONDS = 30 * 24 * 60 * 60; // 30 days
 const NFT_PAGE_SIZE = 50;
 
 const checksummedBasePaintAddress = getAddress(BASEPAINT_CONTRACT_ADDRESS);
+const zeroAddress = getAddress(ZeroAddress);
+const erc1155Interface = new Interface([
+  "event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)",
+  "event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values)",
+]);
+
+const getListingExpirationTime = () =>
+  Math.floor(Date.now() / 1000) + LISTING_DURATION_SECONDS;
 
 const normalizeAddress = (address?: string | null) => {
   if (!address) {
@@ -46,19 +62,99 @@ const getOpenSeaClient = (signer: Wallet) =>
     apiKey: process.env.OPENSEA_API_KEY,
   });
 
+const extractMintedTokenQuantities = (logs: Iterable<Log>, recipient: string) => {
+  const mintedTokenQuantities = new Map<string, bigint>();
+  const normalizedRecipient = normalizeAddress(recipient);
+
+  if (!normalizedRecipient) {
+    return mintedTokenQuantities;
+  }
+
+  for (const log of logs) {
+    const logAddress = normalizeAddress(log?.address);
+
+    if (logAddress !== checksummedBasePaintAddress) {
+      continue;
+    }
+
+    let parsedLog;
+
+    try {
+      parsedLog = erc1155Interface.parseLog(log);
+    } catch (error) {
+      continue;
+    }
+
+    const from = normalizeAddress(parsedLog.args?.from);
+    const to = normalizeAddress(parsedLog.args?.to);
+
+    if (from !== zeroAddress || to !== normalizedRecipient) {
+      continue;
+    }
+
+    if (parsedLog.name === "TransferSingle") {
+      const tokenId = parsedLog.args?.id;
+      const value = parsedLog.args?.value;
+
+      if (tokenId == null || value == null) {
+        continue;
+      }
+
+      const tokenIdString = tokenId.toString();
+      const quantity = BigInt(value.toString());
+
+      if (quantity <= 0n) {
+        continue;
+      }
+
+      const existingQuantity = mintedTokenQuantities.get(tokenIdString) ?? 0n;
+      mintedTokenQuantities.set(tokenIdString, existingQuantity + quantity);
+    }
+
+    if (parsedLog.name === "TransferBatch") {
+      const tokenIds = (parsedLog.args?.ids ?? []) as readonly (
+        bigint | number | string
+      )[];
+      const quantities = (parsedLog.args?.values ?? []) as readonly (
+        bigint | number | string
+      )[];
+
+      tokenIds.forEach((tokenId, index) => {
+        const quantityRaw = quantities[index];
+
+        if (quantityRaw == null) {
+          return;
+        }
+
+        const quantity = BigInt(quantityRaw.toString());
+
+        if (quantity <= 0n) {
+          return;
+        }
+
+        const tokenIdString = tokenId.toString();
+        const existingQuantity = mintedTokenQuantities.get(tokenIdString) ?? 0n;
+        mintedTokenQuantities.set(tokenIdString, existingQuantity + quantity);
+      });
+    }
+  }
+
+  return mintedTokenQuantities;
+};
+
 const listAllBasePaintNftsForSale = async (
   client: OpenSeaSDK,
   accountAddress: string,
+  processedTokenIds: Set<string>,
+  expirationTime: number,
 ) => {
   const normalizedAccount = normalizeAddress(accountAddress);
 
   if (!normalizedAccount) {
     throw new Error("Invalid account address provided");
   }
-  const expirationTime = Math.floor(Date.now() / 1000) + LISTING_DURATION_SECONDS;
   let cursor: string | undefined;
   const failedTokenIds: string[] = [];
-  const processedTokenIds = new Set<string>();
 
   do {
     const response = await client.api.getNFTsByAccount(
@@ -100,6 +196,9 @@ const listAllBasePaintNftsForSale = async (
       }
 
       try {
+        console.info(
+          `Listing BasePaint token ${nft.identifier} with quantity ${quantityOwned}`,
+        );
         await client.createListing({
           asset: {
             tokenAddress: BASEPAINT_CONTRACT_ADDRESS,
@@ -108,7 +207,7 @@ const listAllBasePaintNftsForSale = async (
           },
           accountAddress: normalizedAccount,
           startAmount: LISTING_PRICE_ETH,
-          quantity: quantityOwned,
+          quantity: quantityOwned.toString(),
           expirationTime,
         });
         processedTokenIds.add(nft.identifier);
@@ -124,6 +223,69 @@ const listAllBasePaintNftsForSale = async (
   if (failedTokenIds.length > 0) {
     throw new Error(
       `Failed to list BasePaint NFTs: ${failedTokenIds.join(", ")}`,
+    );
+  }
+};
+
+const listMintedBasePaintNftsForSale = async (
+  client: OpenSeaSDK,
+  accountAddress: string,
+  mintedTokenQuantities: Map<string, bigint>,
+  processedTokenIds: Set<string>,
+  expirationTime: number,
+) => {
+  if (mintedTokenQuantities.size === 0) {
+    console.info("No newly minted BasePaint tokens detected in transaction receipt");
+    return;
+  }
+
+  const normalizedAccount = normalizeAddress(accountAddress);
+
+  if (!normalizedAccount) {
+    throw new Error("Invalid account address provided");
+  }
+
+  const failedTokenIds: string[] = [];
+
+  for (const [tokenId, quantity] of mintedTokenQuantities) {
+    if (processedTokenIds.has(tokenId)) {
+      continue;
+    }
+
+    const quantityString = quantity.toString();
+
+    if (quantity <= 0n) {
+      continue;
+    }
+
+    try {
+      console.info(
+        `Listing newly minted BasePaint token ${tokenId} with quantity ${quantityString}`,
+      );
+      await client.createListing({
+        asset: {
+          tokenAddress: BASEPAINT_CONTRACT_ADDRESS,
+          tokenId,
+          tokenStandard: TokenStandard.ERC1155,
+        },
+        accountAddress: normalizedAccount,
+        startAmount: LISTING_PRICE_ETH,
+        quantity: quantityString,
+        expirationTime,
+      });
+      processedTokenIds.add(tokenId);
+    } catch (error) {
+      console.error(
+        `Failed to list newly minted BasePaint token ${tokenId}:`,
+        error,
+      );
+      failedTokenIds.push(tokenId);
+    }
+  }
+
+  if (failedTokenIds.length > 0) {
+    throw new Error(
+      `Failed to list newly minted BasePaint NFTs: ${failedTokenIds.join(", ")}`,
     );
   }
 };
@@ -161,10 +323,41 @@ export async function GET(req: NextRequest) {
       },
     );
 
-    await tx.wait();
+    const receipt = await tx.wait();
 
     const openSeaClient = getOpenSeaClient(signer);
-    await listAllBasePaintNftsForSale(openSeaClient, recipient);
+    const mintedTokenQuantities = extractMintedTokenQuantities(
+      receipt.logs,
+      recipient,
+    );
+    const processedTokenIds = new Set<string>();
+    const expirationTime = getListingExpirationTime();
+
+    if (mintedTokenQuantities.size > 0) {
+      console.info(
+        "Detected newly minted BasePaint tokens",
+        Array.from(mintedTokenQuantities.entries()).map(
+          ([tokenId, quantity]) => ({
+            tokenId,
+            quantity: quantity.toString(),
+          }),
+        ),
+      );
+    }
+
+    await listAllBasePaintNftsForSale(
+      openSeaClient,
+      recipient,
+      processedTokenIds,
+      expirationTime,
+    );
+    await listMintedBasePaintNftsForSale(
+      openSeaClient,
+      recipient,
+      mintedTokenQuantities,
+      processedTokenIds,
+      expirationTime,
+    );
 
     return new Response("BasePaint minted successfully", {
       status: 200,


### PR DESCRIPTION
## Summary
- parse newly minted BasePaint ERC-1155 transfer logs to capture token quantities directly from the mint transaction
- reuse the parsed results and processed token tracking to ensure every owned token is listed while adding detailed logging for debugging
- fall back to listing only the remaining freshly minted tokens when the OpenSea inventory API has not indexed them yet

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68e18182b5188332ac56f60721095a32