### PR TITLE
Handle missing Farcaster users gracefully

### DIFF
--- a/app/lib/external/farcaster.ts
+++ b/app/lib/external/farcaster.ts
@@ -31,6 +31,15 @@ export async function getFarcasterUser(
 
     if (!response.ok) {
       const errorText = await response.text();
+
+      if (response.status === 404) {
+        console.info(
+          "Farcaster user not found for address, skipping update",
+          normalizedAddress,
+        );
+        return null;
+      }
+
       throw new Error(
         `Failed to fetch Farcaster user: ${response.statusText} (${response.status})\nResponse: ${errorText}`,
       );


### PR DESCRIPTION
## Summary
- avoid throwing errors when the Neynar API responds with 404 for a Farcaster lookup
- log an informational message and return null so check-in processing can continue

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e531e4da0483328dacc6ebb5ba3337