### PR TITLE
fix: stop sending undefined values to Alchemy NFT API

### DIFF
--- a/app/lib/api/getNFTsForOwner.ts
+++ b/app/lib/api/getNFTsForOwner.ts
@@ -17,15 +17,20 @@ export const fetchNFTsForOwner = async ({
   pageKey,
   size,
 }: Props) => {
-  const response = await fetch(
-    `${baseNFTUrl}/getNFTsForOwner?owner=${address}&contractAddresses%5B%5D=${contract}&withMetadata=true&pageSize=${size}&pageKey=${pageKey}&orderBy=null`,
-    {
-      next: {
-        revalidate: 43_200, // 12 hours
-        tags: [`getNFTsForOwner-${address}`],
-      },
+  const params = new URLSearchParams({
+    owner: address ?? "",
+    "contractAddresses[]": contract,
+    withMetadata: "true",
+  });
+  if (size !== undefined) params.set("pageSize", String(size));
+  if (pageKey) params.set("pageKey", pageKey);
+
+  const response = await fetch(`${baseNFTUrl}/getNFTsForOwner?${params}`, {
+    next: {
+      revalidate: 43_200, // 12 hours
+      tags: [`getNFTsForOwner-${address}`],
     },
-  );
+  });
   return (await response.json()) as AlchemyUserResponse;
 };
 


### PR DESCRIPTION
## Summary
The \`/raid\` page was showing \"No Pot Raiders found in 0x…\" for users who actually hold Pot Raiders. The root cause is **not** OpenSea — the NFT list is fetched from Alchemy, and the URL builder was interpolating literal \`undefined\` into the query string.

## Root cause
\`fetchNFTsForOwner\` used a template literal:
\`\`\`
…&pageSize=\${size}&pageKey=\${pageKey}&orderBy=null
\`\`\`
The \`/raid\` NFTList calls \`useGetOwnerNFTs({ address, contract })\` with no \`size\` or \`pageKey\`, so the URL became:
\`\`\`
…&pageSize=undefined&pageKey=undefined&orderBy=null
\`\`\`
Alchemy NFT v3 used to tolerate this. It now returns **HTTP 500** (\`Unexpected internal error\`) and the empty response renders as \"No Pot Raiders found\". /burn isn't affected because its TabUser passes \`size=42\` and an empty-string \`pageKey\`, which Alchemy still accepts.

Verified the user's address (\`0x1d671d1B191323A38490972D58354971E5c1cd2A\`) holds **140 Pot Raiders** via Alchemy \`getOwnersForContract\`, and the cleaned URL returns 200.

## Fix
Build the query with \`URLSearchParams\` and only set \`pageSize\`/\`pageKey\` when actually provided. Drop \`orderBy=null\` (was a literal \"null\" string, never intentional).

## Test plan
- [ ] Visit /raid while connected with a wallet that holds Pot Raiders — NFTs render
- [ ] Visit /burn — still shows minted Burned Bits (no regression)
- [ ] Wallet with no NFTs — still shows the \"No Pot Raiders found\" empty state correctly