### PR TITLE
chore: point Megapot links to v1.megapot.io

### DIFF
--- a/app/raid/components/MintComponent.tsx
+++ b/app/raid/components/MintComponent.tsx
@@ -54,7 +54,7 @@ export const MintComponent = ({ jackpot, history }: Props) => {
                 For a full year, Pot Raiders will spend a share of the treasury
                 on{" "}
                 <Link
-                  href="https://megapot.io"
+                  href="https://v1.megapot.io"
                   target="_blank"
                   className="underline hover:text-white"
                 >
@@ -158,7 +158,7 @@ export const MintComponent = ({ jackpot, history }: Props) => {
                   Basescan
                 </Link>
                 <Link
-                  href={`https://megapot.io`}
+                  href={`https://v1.megapot.io`}
                   className="underline hover:text-white"
                   target="_blank"
                 >


### PR DESCRIPTION
## Summary
Updates both `megapot.io` links to `https://v1.megapot.io`.

## Changes
Both links live in the Pot Raiders mint component:
- `app/raid/components/MintComponent.tsx:57` — "Megapot tickets" description link
- `app/raid/components/MintComponent.tsx:161` — Megapot link in the contract/links row

A repo-wide search (`grep -rn "megapot.io"` excluding node_modules/.next) found only these two references.