### PR TITLE
feat: reward check-in users with PennyPot lottery shares

### DIFF
--- a/app/api/cron/pennypot/route.ts
+++ b/app/api/cron/pennypot/route.ts
@@ -130,8 +130,11 @@ export async function GET(req: NextRequest) {
         const gas = await pennypot.buyTicket.estimateGas();
         const tx = await pennypot.buyTicket({
           gasLimit: (gas * BUY_TICKET_GAS_BPS) / BigInt(100),
-          nonce: nonce++,
+          nonce,
         });
+        // Only advance the nonce once the tx is actually broadcast; a revert
+        // during estimate/populate rejects without consuming it.
+        nonce++;
         await tx.wait();
       } catch (error) {
         console.error("pennypot cron: buyTicket failed/not buyable", error);
@@ -163,8 +166,12 @@ export async function GET(req: NextRequest) {
             ticketId,
             count,
             recipient,
-            { nonce: nonce++ },
+            { nonce },
           );
+          // Only advance the nonce once broadcast; a pre-broadcast revert
+          // (estimate/populate) rejects without consuming it, so we must not
+          // leave a gap for the next recipient.
+          nonce++;
           await tx.wait();
           succeeded++;
           sharesBought += count;
@@ -172,18 +179,21 @@ export async function GET(req: NextRequest) {
           remaining -= count;
           need -= count;
         } catch (error) {
+          // ethers v6 decodes custom errors by name into `revert.name` (the ABI
+          // now carries the error fragments); fall back to the message string.
+          const revertName =
+            (error as { revert?: { name?: string } })?.revert?.name ?? "";
           const msg = (error as Error)?.message ?? "";
-          // Ticket rolled between read and send — refresh and retry the user once.
-          if (
-            !retried &&
-            /UnexpectedTicket|PastSellingWindow|NoActiveTicket/.test(msg)
-          ) {
+          const rolled =
+            /UnexpectedTicket|PastSellingWindow|NoActiveTicket|InvalidCount/.test(
+              `${revertName} ${msg}`,
+            );
+          // Ticket rolled/filled between read and send — refresh and retry once.
+          if (!retried && rolled) {
             retried = true;
             state = await readState(pennypot);
             ticketId = state.ticketId;
             remaining = ticketId === ZERO ? 0 : SHARES_PER_TICKET - state.sold;
-            // resync nonce in case the failed tx never broadcast
-            nonce = await baseProvider.getTransactionCount(signer.address);
             continue;
           }
           console.error(

--- a/app/api/cron/pennypot/route.ts
+++ b/app/api/cron/pennypot/route.ts
@@ -1,0 +1,212 @@
+import { getCheckins } from "@/app/lib/api/getCheckins";
+import { getPennyPotKeeper } from "@/app/lib/contracts/pennypot";
+import { baseProvider } from "@/app/lib/Web3Configs";
+import { MaxUint256 } from "ethers";
+import { NextRequest } from "next/server";
+import { getAddress, isAddress } from "viem";
+
+// buyTicket()'s gas swings (~1.04M–1.2M+) with Megapot state; a bare estimate has
+// OOG'd in the PennyPot keeper, so pad the gasLimit. Unused gas is refunded.
+const BUY_TICKET_GAS_BPS = BigInt(160);
+
+// PennyPot economics (Base): 100 shares per ticket, 1¢ (10_000 USDC units) each.
+const SHARES_PER_TICKET = 100;
+const SHARE_PRICE = BigInt(10_000); // 0.01 USDC (6 decimals)
+const ZERO = BigInt(0);
+
+export const maxDuration = 300;
+
+type State = {
+  ticketId: bigint;
+  sold: number;
+  canBuyNextTicket: boolean;
+  isPaused: boolean;
+};
+
+const readState = async (
+  pennypot: ReturnType<typeof getPennyPotKeeper>["pennypot"],
+): Promise<State> => {
+  const s = await pennypot.getState();
+  return {
+    ticketId: s.currentTicketId as bigint,
+    sold: Number(s.sold as bigint),
+    canBuyNextTicket: s.canBuyNextTicket as boolean,
+    isPaused: s.isPaused as boolean,
+  };
+};
+
+export async function GET(req: NextRequest) {
+  try {
+    const authHeader = req.headers.get("authorization");
+    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    // 1. Recipients: unique valid addresses that checked in over the last 24h,
+    //    most-recent first (getCheckins is ordered by block_number desc).
+    const checkins = await getCheckins(86_400);
+    const seen = new Set<string>();
+    const recipients: string[] = [];
+    for (const c of checkins) {
+      const addr = c.user?.address;
+      if (!addr || !isAddress(addr)) continue;
+      const key = addr.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      recipients.push(getAddress(addr));
+    }
+    const numUsers = recipients.length;
+    if (numUsers === 0) {
+      return Response.json({ ok: true, message: "no check-ins", numUsers: 0 });
+    }
+
+    // 2. Allocation: split the $1/day budget (100 shares) evenly. >100 users
+    //    would mean 0 whole shares each — skip.
+    const sharesPerUser = Math.floor(SHARES_PER_TICKET / numUsers);
+    if (sharesPerUser === 0) {
+      return Response.json({
+        ok: true,
+        message: "too many users for whole shares; skipped",
+        numUsers,
+      });
+    }
+    const totalShares = sharesPerUser * numUsers;
+    const totalCost = BigInt(totalShares) * SHARE_PRICE;
+
+    const { signer, pennypot, usdc } = getPennyPotKeeper();
+
+    // 3. Gates.
+    let state = await readState(pennypot);
+    if (state.isPaused) {
+      return Response.json({ ok: false, message: "PennyPot paused", numUsers });
+    }
+
+    const balance = (await usdc.balanceOf(signer.address)) as bigint;
+    if (balance < totalCost) {
+      console.error(
+        `pennypot cron: insufficient USDC. have=${balance} need=${totalCost} (${totalShares} shares)`,
+      );
+      return Response.json({
+        ok: false,
+        message: "insufficient USDC; skipped",
+        numUsers,
+        sharesPerUser,
+        haveUsdc: balance.toString(),
+        needUsdc: totalCost.toString(),
+      });
+    }
+
+    const allowance = (await usdc.allowance(
+      signer.address,
+      await pennypot.getAddress(),
+    )) as bigint;
+    if (allowance < totalCost) {
+      try {
+        const tx = await usdc.approve(await pennypot.getAddress(), MaxUint256);
+        await tx.wait();
+      } catch (error) {
+        console.error("pennypot cron: USDC approve failed", error);
+        return Response.json({
+          ok: false,
+          message: "approve failed",
+          numUsers,
+        });
+      }
+    }
+
+    // 4. Buy loop. Front a fresh ticket whenever the active one is full / absent.
+    let nonce = await baseProvider.getTransactionCount(signer.address);
+    let remaining =
+      state.ticketId === ZERO ? 0 : SHARES_PER_TICKET - state.sold;
+    let ticketId = state.ticketId;
+    const ticketIds = new Set<string>();
+    let attempted = 0;
+    let succeeded = 0;
+    let sharesBought = 0;
+    let stop = false;
+
+    const frontNextTicket = async (): Promise<boolean> => {
+      try {
+        const gas = await pennypot.buyTicket.estimateGas();
+        const tx = await pennypot.buyTicket({
+          gasLimit: (gas * BUY_TICKET_GAS_BPS) / BigInt(100),
+          nonce: nonce++,
+        });
+        await tx.wait();
+      } catch (error) {
+        console.error("pennypot cron: buyTicket failed/not buyable", error);
+        return false;
+      }
+      state = await readState(pennypot);
+      ticketId = state.ticketId;
+      remaining = ticketId === ZERO ? 0 : SHARES_PER_TICKET - state.sold;
+      return ticketId !== ZERO && remaining > 0;
+    };
+
+    for (const recipient of recipients) {
+      if (stop) break;
+      let need = sharesPerUser;
+      let retried = false;
+
+      while (need > 0) {
+        if (ticketId === ZERO || remaining === 0) {
+          if (!(await frontNextTicket())) {
+            stop = true;
+            break;
+          }
+        }
+
+        const count = Math.min(need, remaining);
+        attempted++;
+        try {
+          const tx = await pennypot.buyTicketSharesFor(
+            ticketId,
+            count,
+            recipient,
+            { nonce: nonce++ },
+          );
+          await tx.wait();
+          succeeded++;
+          sharesBought += count;
+          ticketIds.add(ticketId.toString());
+          remaining -= count;
+          need -= count;
+        } catch (error) {
+          const msg = (error as Error)?.message ?? "";
+          // Ticket rolled between read and send — refresh and retry the user once.
+          if (
+            !retried &&
+            /UnexpectedTicket|PastSellingWindow|NoActiveTicket/.test(msg)
+          ) {
+            retried = true;
+            state = await readState(pennypot);
+            ticketId = state.ticketId;
+            remaining = ticketId === ZERO ? 0 : SHARES_PER_TICKET - state.sold;
+            // resync nonce in case the failed tx never broadcast
+            nonce = await baseProvider.getTransactionCount(signer.address);
+            continue;
+          }
+          console.error(
+            `pennypot cron: buyTicketSharesFor failed for ${recipient}`,
+            error,
+          );
+          break; // skip this user
+        }
+      }
+    }
+
+    return Response.json({
+      ok: true,
+      numUsers,
+      sharesPerUser,
+      attempted,
+      succeeded,
+      sharesBought,
+      spentUsdc: (BigInt(sharesBought) * SHARE_PRICE).toString(),
+      ticketIds: Array.from(ticketIds),
+    });
+  } catch (error) {
+    console.error("pennypot cron: internal error", error);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}

--- a/app/lib/abi/PennyPot.abi.ts
+++ b/app/lib/abi/PennyPot.abi.ts
@@ -36,4 +36,17 @@ export const PennyPotABI = [
     inputs: [],
     outputs: [],
   },
+  // Custom errors — required so ethers v6 can decode reverts by name. The buy
+  // loop relies on these names to detect a ticket that rolled/filled mid-run.
+  {
+    type: "error",
+    name: "UnexpectedTicket",
+    inputs: [
+      { name: "active", type: "uint256" },
+      { name: "expected", type: "uint256" },
+    ],
+  },
+  { type: "error", name: "PastSellingWindow", inputs: [] },
+  { type: "error", name: "NoActiveTicket", inputs: [] },
+  { type: "error", name: "InvalidCount", inputs: [] },
 ] as const;

--- a/app/lib/abi/PennyPot.abi.ts
+++ b/app/lib/abi/PennyPot.abi.ts
@@ -1,0 +1,39 @@
+// Minimal ABI for the PennyPot functions the check-in rewards cron calls.
+// Hand-authored because the live deployment
+// (0x133195CEd7Cf71A7ed3a428a30816d83f022C9A1) is unverified on the explorer.
+// Source of truth: andreitr/pennypot. `buyTicketSharesFor` selector 0xf6e2e620.
+export const PennyPotABI = [
+  {
+    type: "function",
+    name: "getState",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [
+      { name: "currentDrawingId", type: "uint256" },
+      { name: "currentTicketId", type: "uint256" },
+      { name: "sold", type: "uint8" },
+      { name: "deadline", type: "uint64" },
+      { name: "canBuyNextTicket", type: "bool" },
+      { name: "reserve", type: "uint256" },
+      { name: "isPaused", type: "bool" },
+    ],
+  },
+  {
+    type: "function",
+    name: "buyTicketSharesFor",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "expectedTicketId", type: "uint256" },
+      { name: "count", type: "uint8" },
+      { name: "recipient", type: "address" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "buyTicket",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [],
+  },
+] as const;

--- a/app/lib/contracts/pennypot.ts
+++ b/app/lib/contracts/pennypot.ts
@@ -1,0 +1,27 @@
+import { baseProvider } from "@/app/lib/Web3Configs";
+import { PennyPotABI } from "@/app/lib/abi/PennyPot.abi";
+import { Contract, Wallet } from "ethers";
+
+// Base mainnet USDC (6 decimals). PennyPot shares are priced in USDC.
+export const USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+// Minimal ERC20 surface the cron needs: read balance/allowance, approve PennyPot.
+const ERC20_ABI = [
+  "function balanceOf(address owner) view returns (uint256)",
+  "function allowance(address owner, address spender) view returns (uint256)",
+  "function approve(address spender, uint256 amount) returns (bool)",
+] as const;
+
+// The check-in rewards cron pays for shares from the existing BBITS airdrop
+// wallet (AIRDROP_BOT_PK). buyTicketSharesFor / buyTicket are permissionless,
+// so the bot only needs USDC + ETH (gas), not the contract owner role.
+export const getPennyPotKeeper = () => {
+  const signer = new Wallet(process.env.AIRDROP_BOT_PK as string, baseProvider);
+  const pennypot = new Contract(
+    process.env.NEXT_PUBLIC_PENNYPOT_ADDRESS as string,
+    PennyPotABI,
+    signer,
+  );
+  const usdc = new Contract(USDC_ADDRESS, ERC20_ABI, signer);
+  return { signer, pennypot, usdc };
+};

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
       "schedule": "0 7 * * *"
     },
     {
+      "path": "/api/cron/pennypot",
+      "schedule": "0 8 * * *"
+    },
+    {
       "path": "/api/bots/backfill/checkins",
       "schedule": "0 0 * * *"
     },


### PR DESCRIPTION
## Summary
Adds a daily cron that rewards everyone who checked in over the previous 24h with Megapot lottery **shares**, bought through the **PennyPot** contract on Base. Each user owns their shares on-chain (how they claim is out of scope).

- **Route:** `app/api/cron/pennypot/route.ts` — scheduled `0 8 * * *` (08:00 UTC, just after the BBITS airdrop at 07:00; both key on the prior 24h).
- **Contract:** PennyPot `0x133195CEd7Cf71A7ed3a428a30816d83f022C9A1` (live deploy; canonical per `andreitr/pennypot/.../addresses.ts`). 100 shares = one $1 ticket, 1¢/share.

## How it works
1. Pull last-24h check-ins (`getCheckins(86_400)`), dedupe to unique valid addresses (most-recent first).
2. **Dynamic allocation:** `sharesPerUser = floor(100 / uniqueUsers)` — 10 users → 10 shares each, 20 → 5. Total ≤ 100 shares = ≤ **$1/day** (over-budget is impossible by construction).
3. Buy per user via `buyTicketSharesFor(expectedTicketId, count, recipient)` (selector `0xf6e2e620`) so shares land in each user's address. Paid from the existing **`AIRDROP_BOT_PK`** wallet; auto-approves USDC to PennyPot on first run.
4. When the active ticket fills mid-run, front the next with `buyTicket()` (gasLimit padded ×1.60 — bare estimates have OOG'd in the PennyPot keeper) and resume. At most one front/run since the daily total is ≤ 100 shares.
5. **Race handling:** every buy passes `expectedTicketId`; on `UnexpectedTicket`/`PastSellingWindow` it re-reads state and retries the user once.

## Decisions (confirmed with owner)
| Topic | Behavior |
|---|---|
| Attribution | `buyTicketSharesFor` → per-user on-chain ownership |
| Amount | dynamic `floor(100/users)`, ≤ $1/day |
| Ticket supply | front a new ticket and resume (no round/snapshot handling — cron runs mid-drawing) |
| Low balance | **skip entirely** if USDC < day's intended spend |
| Wallet | reuse `AIRDROP_BOT_PK` |

## Config / ops
- New env: **`NEXT_PUBLIC_PENNYPOT_ADDRESS`** (added to local `.env`; **must be set in Vercel**). Default points at the live deploy.
- The `AIRDROP_BOT_PK` wallet must hold **USDC** (shares) + **ETH** (gas).
- The PennyPot ABI is hand-authored (`app/lib/abi/PennyPot.abi.ts`) since the deploy is unverified — only `getState` / `buyTicketSharesFor` / `buyTicket` are needed.

## Out of scope
- Settlement/snapshot/claim of winnings (PennyPot's own keeper handles drawing boundaries).
- User-facing UI for viewing owned shares.

## Test plan
- [ ] `yarn build` passes (done locally; route registered)
- [ ] Dry-run on a funded test wallet: verify one `SharesBought(ticketId, recipient, count, …)` per user and `getTicketShares(ticketId, user)` matches
- [ ] Edge: 0 users / >100 users / paused / low balance all skip cleanly
- [ ] Edge: active ticket fills mid-run → new ticket fronted, shares land on both ticket IDs