### PR TITLE
fix(pennypot): default contract address so the cron stops crashing

### DIFF
--- a/app/lib/contracts/pennypot.ts
+++ b/app/lib/contracts/pennypot.ts
@@ -5,13 +5,10 @@ import { Contract, Wallet } from "ethers";
 // Base mainnet USDC (6 decimals). PennyPot shares are priced in USDC.
 export const USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 
-// Live PennyPot deployment on Base. Defaulted in code (not just env) because
-// NEXT_PUBLIC_* vars are inlined at build time — a missing/late env var would
-// leave the Contract target undefined at runtime. Override via env if needed.
-// Mirrors andreitr/pennypot packages/web/lib/addresses.ts.
-export const PENNYPOT_ADDRESS =
-  process.env.NEXT_PUBLIC_PENNYPOT_ADDRESS ??
-  "0x133195CEd7Cf71A7ed3a428a30816d83f022C9A1";
+// Live PennyPot deployment on Base. Hardcoded constant: this is server-only
+// cron code against a fixed contract, so there's no env override (and NEXT_PUBLIC_*
+// vars are inlined at build time anyway, which previously left the target undefined).
+export const PENNYPOT_ADDRESS = "0x133195CEd7Cf71A7ed3a428a30816d83f022C9A1";
 
 // Minimal ERC20 surface the cron needs: read balance/allowance, approve PennyPot.
 const ERC20_ABI = [

--- a/app/lib/contracts/pennypot.ts
+++ b/app/lib/contracts/pennypot.ts
@@ -5,6 +5,14 @@ import { Contract, Wallet } from "ethers";
 // Base mainnet USDC (6 decimals). PennyPot shares are priced in USDC.
 export const USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 
+// Live PennyPot deployment on Base. Defaulted in code (not just env) because
+// NEXT_PUBLIC_* vars are inlined at build time — a missing/late env var would
+// leave the Contract target undefined at runtime. Override via env if needed.
+// Mirrors andreitr/pennypot packages/web/lib/addresses.ts.
+export const PENNYPOT_ADDRESS =
+  process.env.NEXT_PUBLIC_PENNYPOT_ADDRESS ??
+  "0x133195CEd7Cf71A7ed3a428a30816d83f022C9A1";
+
 // Minimal ERC20 surface the cron needs: read balance/allowance, approve PennyPot.
 const ERC20_ABI = [
   "function balanceOf(address owner) view returns (uint256)",
@@ -16,12 +24,11 @@ const ERC20_ABI = [
 // wallet (AIRDROP_BOT_PK). buyTicketSharesFor / buyTicket are permissionless,
 // so the bot only needs USDC + ETH (gas), not the contract owner role.
 export const getPennyPotKeeper = () => {
-  const signer = new Wallet(process.env.AIRDROP_BOT_PK as string, baseProvider);
-  const pennypot = new Contract(
-    process.env.NEXT_PUBLIC_PENNYPOT_ADDRESS as string,
-    PennyPotABI,
-    signer,
-  );
+  const pk = process.env.AIRDROP_BOT_PK;
+  if (!pk) throw new Error("AIRDROP_BOT_PK is not set");
+
+  const signer = new Wallet(pk, baseProvider);
+  const pennypot = new Contract(PENNYPOT_ADDRESS, PennyPotABI, signer);
   const usdc = new Contract(USDC_ADDRESS, ERC20_ABI, signer);
   return { signer, pennypot, usdc };
 };


### PR DESCRIPTION
## Problem
The `/api/cron/pennypot` run threw:
```
TypeError: invalid value for Contract target (argument="target", value=null, code=INVALID_ARGUMENT)
```
`NEXT_PUBLIC_PENNYPOT_ADDRESS` was unset in the deployed env, so the PennyPot `Contract` was constructed with `undefined`. Compounding it: `NEXT_PUBLIC_*` vars are **inlined at build time**, so setting the var in Vercel after the build wouldn't fix the already-built server bundle anyway.

## Fix
Default `PENNYPOT_ADDRESS` in code to the live Base deploy `0x133195CEd7Cf71A7ed3a428a30816d83f022C9A1`, overridable via env — mirroring the `andreitr/pennypot` repo's own `addresses.ts`. Also throw a clear error if `AIRDROP_BOT_PK` is missing instead of failing opaquely later.

Follow-up to #43 (which merged before this fix landed).

## Test plan
- [x] `yarn build` passes; route registered
- [ ] Re-run the cron on a funded wallet and confirm no `Contract target` error