### PR TITLE
chore(pennypot): point buys at the redeployed contract

### DIFF
--- a/app/lib/abi/PennyPot.abi.ts
+++ b/app/lib/abi/PennyPot.abi.ts
@@ -1,6 +1,5 @@
 // Minimal ABI for the PennyPot functions the check-in rewards cron calls.
-// Hand-authored because the live deployment
-// (0x133195CEd7Cf71A7ed3a428a30816d83f022C9A1) is unverified on the explorer.
+// Hand-authored for the live deployment 0x68C2F365DA5D55CC4CdbD4fE3A3a10EE56d0846A.
 // Source of truth: andreitr/pennypot. `buyTicketSharesFor` selector 0xf6e2e620.
 export const PennyPotABI = [
   {

--- a/app/lib/contracts/pennypot.ts
+++ b/app/lib/contracts/pennypot.ts
@@ -8,7 +8,7 @@ export const USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 // Live PennyPot deployment on Base. Hardcoded constant: this is server-only
 // cron code against a fixed contract, so there's no env override (and NEXT_PUBLIC_*
 // vars are inlined at build time anyway, which previously left the target undefined).
-export const PENNYPOT_ADDRESS = "0x133195CEd7Cf71A7ed3a428a30816d83f022C9A1";
+export const PENNYPOT_ADDRESS = "0x68C2F365DA5D55CC4CdbD4fE3A3a10EE56d0846A";
 
 // Minimal ERC20 surface the cron needs: read balance/allowance, approve PennyPot.
 const ERC20_ABI = [


### PR DESCRIPTION
## Summary
Points the daily check-in PennyPot rewards cron at the **redeployed** contract.

- `PENNYPOT_ADDRESS`: `0x133195…C9A1` → **`0x68C2F365DA5D55CC4CdbD4fE3A3a10EE56d0846A`** in `app/lib/contracts/pennypot.ts`.
- Updated the `PennyPot.abi.ts` header comment to match.

The cron (`/api/cron/pennypot`) and `getPennyPotKeeper()` both flow through this constant, so the address swap is the only functional change. The hand-authored ABI subset (`getState`, `buyTicketSharesFor(uint256,uint8,address)`, `buyTicket`) is assumed unchanged on the redeploy.

## Test plan
- [x] `yarn build` compiles; `grep 0x133195 app/` → none
- [ ] Post-deploy: invoke the cron (or a dry `getState()` read) against the new address to confirm the ABI still matches — `getState` returns the 7-tuple and a buy emits `SharesBought`. Requires the funded `AIRDROP_BOT_PK` wallet.